### PR TITLE
[VET-4438] Add isLaunchpad to connection cookie

### DIFF
--- a/src/cookies/connection.ts
+++ b/src/cookies/connection.ts
@@ -11,6 +11,8 @@ export type ConnectionCookie = {
   // optional because older cloud versions might not contain these
   tokenEndpoint?: string;
   graphqlEndpoint?: string;
+  isPortal?: boolean;
+  isLaunchpad?: boolean;
 };
 
 export const decodeConnectionCookie = (

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -44,6 +44,11 @@ export type ArchivedCloud = {
   region?: Maybe<Scalars['String']>;
 };
 
+export type AzureProvider = {
+  __typename?: 'AzureProvider';
+  customerName: Scalars['String'];
+};
+
 export type BillingSession = {
   __typename?: 'BillingSession';
   session_id?: Maybe<Scalars['String']>;
@@ -107,6 +112,11 @@ export type Connection = {
   username?: Maybe<Scalars['String']>;
 };
 
+export type CustomerSsoSettings = {
+  __typename?: 'CustomerSsoSettings';
+  azureProviders: Array<Maybe<AzureProvider>>;
+};
+
 /** Generic deletion response type to handle reporting success. */
 export type DeletionResponse = {
   __typename?: 'DeletionResponse';
@@ -168,6 +178,11 @@ export type InvitationInput = {
   email: Scalars['String'];
   endpoint: Scalars['String'];
   role: Scalars['String'];
+};
+
+export type ItemCount = {
+  __typename?: 'ItemCount';
+  count?: Maybe<Scalars['Int']>;
 };
 
 export type MarketplaceSettings = {
@@ -305,6 +320,12 @@ export type OAuthToken = {
   user: User;
 };
 
+/** To page through response. */
+export type PagingInput = {
+  limit?: InputMaybe<Scalars['Int']>;
+  offset?: InputMaybe<Scalars['Int']>;
+};
+
 /** Databricks Partner Information */
 export type PartnerConnectionDetail = {
   __typename?: 'PartnerConnectionDetail';
@@ -347,6 +368,7 @@ export type PurchaseSession = {
 export type Query = {
   __typename?: 'Query';
   checkCloudQueue?: Maybe<QueueCounts>;
+  customerSsoSettings?: Maybe<CustomerSsoSettings>;
   generateToken?: Maybe<OAuthToken>;
   getConnection?: Maybe<Connection>;
   getConnectionByIndex?: Maybe<Connection>;
@@ -362,16 +384,28 @@ export type Query = {
   getUserConnections?: Maybe<Array<Maybe<Connection>>>;
   getUserCurrentPartnerConnection?: Maybe<PartnerConnectionDetail>;
   getUserSearchDetails?: Maybe<UserSearchDetails>;
+  /** Retrieve a single Voicebox conversation for the authenticated user by the conversation id. */
+  getVoiceboxConversation?: Maybe<VoiceboxConversation>;
   grafanaHighLevelDashboardSettings?: Maybe<GrafanaDashboardSettings>;
   listConnections?: Maybe<Array<Maybe<Connection>>>;
   listConnectionsByEndpoint?: Maybe<Array<Maybe<Connection>>>;
   listInactiveClouds?: Maybe<Array<Maybe<StardogCloud>>>;
   listStardogCloud?: Maybe<Array<Maybe<StardogCloud>>>;
+  /**
+   * Retrieve Voicebox conversations for the authenticated user, ordered by creation date, with the newest first.
+   * Use PagingInput to paginate. If PagingInput is omitted, all conversations are returned.
+   */
+  listVoiceboxConversations?: Maybe<Array<Maybe<VoiceboxConversation>>>;
   marketplaceSettings?: Maybe<MarketplaceSettings>;
   profile?: Maybe<User>;
   searchUsers?: Maybe<Array<Maybe<User>>>;
   settings: Settings;
   userPartnerConnections?: Maybe<Array<Maybe<PartnerConnectionDetail>>>;
+  /**
+   * Get the amount of total Voicebox conversation's an authenticated user. May be helpful in conjunction with listVoiceboxConversations
+   * to page through all conversations.
+   */
+  voiceboxConversationCount?: Maybe<ItemCount>;
 };
 
 /** Available queries */
@@ -436,6 +470,11 @@ export type QueryGetUserSearchDetailsArgs = {
 };
 
 /** Available queries */
+export type QueryGetVoiceboxConversationArgs = {
+  conversation_id: Scalars['String'];
+};
+
+/** Available queries */
 export type QueryListConnectionsByEndpointArgs = {
   endpoint: Scalars['String'];
 };
@@ -448,6 +487,11 @@ export type QueryListInactiveCloudsArgs = {
 /** Available queries */
 export type QueryListStardogCloudArgs = {
   inactive_days?: InputMaybe<Scalars['Int']>;
+};
+
+/** Available queries */
+export type QueryListVoiceboxConversationsArgs = {
+  paging?: InputMaybe<PagingInput>;
 };
 
 /** Available queries */
@@ -488,7 +532,6 @@ export type Settings = {
   explorerVersion: Scalars['String'];
   friendlyName: Scalars['String'];
   googleAuth: Scalars['Boolean'];
-  hagertyAuth: Scalars['Boolean'];
   homeFooterLinks: Scalars['Boolean'];
   keycloakAuth: Scalars['Boolean'];
   openidAuth: Scalars['Boolean'];
@@ -593,6 +636,13 @@ export type StripeSubscriptionStatus = {
   status: Scalars['String'];
 };
 
+export type SystemVoiceboxMessageContext = {
+  __typename?: 'SystemVoiceboxMessageContext';
+  actions?: Maybe<Array<Maybe<VoicboxSystemMessageAction>>>;
+  followup_examples?: Maybe<Array<Maybe<Scalars['String']>>>;
+  id: Scalars['ID'];
+};
+
 export type TrackEventInput = {
   client_type?: InputMaybe<Scalars['String']>;
   event: Scalars['String'];
@@ -659,6 +709,48 @@ export type UserSearchDetails = {
 export type UserSearchFiltersInput = {
   is_staff?: InputMaybe<Scalars['Boolean']>;
   is_voicebox_enabled?: InputMaybe<Scalars['Boolean']>;
+};
+
+export type UserVoiceboxMessageContext = {
+  __typename?: 'UserVoiceboxMessageContext';
+  app?: Maybe<Scalars['String']>;
+  connection_id?: Maybe<Scalars['String']>;
+  database?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  model?: Maybe<Scalars['String']>;
+  named_graphs?: Maybe<Array<Maybe<Scalars['String']>>>;
+  reasoning?: Maybe<Scalars['Boolean']>;
+};
+
+export type VoicboxSystemMessageAction = {
+  __typename?: 'VoicboxSystemMessageAction';
+  id: Scalars['ID'];
+  label?: Maybe<Scalars['String']>;
+  type?: Maybe<Scalars['String']>;
+  value?: Maybe<Scalars['String']>;
+};
+
+/** A user's conversation with Voicebox */
+export type VoiceboxConversation = {
+  __typename?: 'VoiceboxConversation';
+  created?: Maybe<Scalars['Datetime']>;
+  id: Scalars['ID'];
+  /** Message history ordered oldest to newest. */
+  message_history?: Maybe<Array<Maybe<VoiceboxMessage>>>;
+  updated?: Maybe<Scalars['Datetime']>;
+};
+
+/** A Message within a Voicebox conversation. */
+export type VoiceboxMessage = {
+  __typename?: 'VoiceboxMessage';
+  comment?: Maybe<Scalars['String']>;
+  content?: Maybe<Scalars['String']>;
+  created?: Maybe<Scalars['Datetime']>;
+  id: Scalars['ID'];
+  score?: Maybe<Scalars['Float']>;
+  sender?: Maybe<Scalars['String']>;
+  system_message_context?: Maybe<SystemVoiceboxMessageContext>;
+  user_message_context?: Maybe<UserVoiceboxMessageContext>;
 };
 
 export type AddShareMutationVariables = Exact<{

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -193,14 +193,13 @@ export type MarketplaceSettings = {
   marketplaceUsername: Scalars['String'];
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type Mutation = {
   __typename?: 'Mutation';
   acceptInvitation?: Maybe<GenericResponse>;
   addConnection?: Maybe<Connection>;
   addInvitation?: Maybe<GenericResponse>;
   addShare?: Maybe<Share>;
-  addStardogFree?: Maybe<StardogFree>;
   cancelCloud?: Maybe<GenericResponse>;
   checkoutCart?: Maybe<BillingSession>;
   deleteAccount?: Maybe<DeletionResponse>;
@@ -219,90 +218,90 @@ export type Mutation = {
   verifyInvitation?: Maybe<GenericResponse>;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationAcceptInvitationArgs = {
   input: InvitationFlagInput;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationAddConnectionArgs = {
   input: AddConnectionInput;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationAddInvitationArgs = {
   input: InvitationInput;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationAddShareArgs = {
   input: ShareInput;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationCancelCloudArgs = {
   input: CancelCloudInput;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationCheckoutCartArgs = {
   addOns?: InputMaybe<Array<InputMaybe<CheckoutLineItem>>>;
   item: CheckoutLineItem;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationDeleteCloudArgs = {
   input: CloudCleanupInput;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationDeleteConnectionArgs = {
   name: Scalars['String'];
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationEditConnectionArgs = {
   input: EditConnectionInput;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationGenerateConfigurationArgs = {
   endpoint: Scalars['String'];
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationRemovePartnerConnectionArgs = {
   input: RemovePartnerConnectionInput;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationTrackEventArgs = {
   input: TrackEventInput;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationUpdatePartnerConnectionArgs = {
   input: UpdatePartnerConnectionInput;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationUpdateProfileArgs = {
   input?: InputMaybe<ProfileInput>;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationUpdateUserFeaturesArgs = {
   input: UserFeaturesInput;
   user_id: Scalars['ID'];
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationUpgradeCloudArgs = {
   connectionId: Scalars['ID'];
   item: CheckoutLineItem;
 };
 
-/** Available mutations */
+/** Root Mutation Type */
 export type MutationVerifyInvitationArgs = {
   input: InvitationFlagInput;
 };
@@ -364,7 +363,7 @@ export type PurchaseSession = {
   url?: Maybe<Scalars['String']>;
 };
 
-/** Available queries */
+/** Root Query Type */
 export type Query = {
   __typename?: 'Query';
   checkCloudQueue?: Maybe<QueueCounts>;
@@ -375,7 +374,6 @@ export type Query = {
   getInvitation?: Maybe<Invitation>;
   getShareByShortHash?: Maybe<Share>;
   getStardogCloud?: Maybe<StardogCloud>;
-  getStardogFree?: Maybe<StardogFree>;
   getStripePrices?: Maybe<Array<Maybe<StripePrice>>>;
   getStripeSubscriptionStatus?: Maybe<StripeSubscriptionStatus>;
   getUser?: Maybe<User>;
@@ -408,93 +406,93 @@ export type Query = {
   voiceboxConversationCount?: Maybe<ItemCount>;
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGenerateTokenArgs = {
   endpoint: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetConnectionArgs = {
   name: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetConnectionByIndexArgs = {
   index: Scalars['Int'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetInvitationArgs = {
   id: Scalars['ID'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetShareByShortHashArgs = {
   shortHash: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetStardogCloudArgs = {
   pk: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetStripeSubscriptionStatusArgs = {
   cloudName: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetUserArgs = {
   user_id: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetUserArchivedCloudsArgs = {
   user_id: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetUserCloudsArgs = {
   user_id: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetUserConnectionsArgs = {
   user_id: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetUserSearchDetailsArgs = {
   filters?: InputMaybe<UserSearchFiltersInput>;
   token: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryGetVoiceboxConversationArgs = {
   conversation_id: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryListConnectionsByEndpointArgs = {
   endpoint: Scalars['String'];
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryListInactiveCloudsArgs = {
   flavor?: InputMaybe<Scalars['String']>;
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryListStardogCloudArgs = {
   inactive_days?: InputMaybe<Scalars['Int']>;
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QueryListVoiceboxConversationsArgs = {
   paging?: InputMaybe<PagingInput>;
 };
 
-/** Available queries */
+/** Root Query Type */
 export type QuerySearchUsersArgs = {
   filters?: InputMaybe<UserSearchFiltersInput>;
   limit: Scalars['Int'];
@@ -576,28 +574,6 @@ export type StardogCloud = {
   region?: Maybe<Scalars['String']>;
   status?: Maybe<Scalars['String']>;
   updated?: Maybe<Scalars['String']>;
-};
-
-/** Stardog Free Installation */
-export type StardogFree = {
-  __typename?: 'StardogFree';
-  company?: Maybe<Scalars['String']>;
-  email?: Maybe<Scalars['String']>;
-  expires?: Maybe<Scalars['String']>;
-  id?: Maybe<Scalars['ID']>;
-  installer?: Maybe<StardogFreeInstaller>;
-  phone?: Maybe<Scalars['String']>;
-  title?: Maybe<Scalars['String']>;
-  use_case?: Maybe<Scalars['String']>;
-  user?: Maybe<User>;
-  version?: Maybe<Scalars['String']>;
-};
-
-export type StardogFreeInstaller = {
-  __typename?: 'StardogFreeInstaller';
-  id?: Maybe<Scalars['ID']>;
-  install_url?: Maybe<Scalars['String']>;
-  version?: Maybe<Scalars['String']>;
 };
 
 /** Stripe Customer: If the user is a paying customer */


### PR DESCRIPTION
[VET-4438] Add isLaunchpad to connection cookie

Ran Yarn Generate after latest cloud-login release

[VET-4438]: https://stardog.atlassian.net/browse/VET-4438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ