### PR TITLE
[VET-6365] Expose getConnectionById from portal-sdk

### DIFF
--- a/src/__tests__/getCurrentConnectionFromPortal.test.ts
+++ b/src/__tests__/getCurrentConnectionFromPortal.test.ts
@@ -10,6 +10,7 @@ describe('getCurrentConnectionFromPortal', () => {
 
     jest.spyOn(getPortalSdkModule, 'getPortalSdk').mockReturnValue({
       addShare: jest.fn(),
+      getConnectionById: jest.fn(),
       getConnectionByIndex,
       getVoiceboxConversation: jest.fn(),
       createDesignerProject: jest.fn(),

--- a/src/__tests__/getPortalSdk.test.ts
+++ b/src/__tests__/getPortalSdk.test.ts
@@ -26,6 +26,14 @@ const archiveDesignerProject = jest.fn(async () => ({
 const createDesignerProject = jest.fn(async () => ({
   createDesignerProject: 'id',
 }));
+const getConnectionById = jest.fn(async () => ({
+  connection: {
+    endpoint: 'endpoint',
+    id: 'id',
+    name: 'name',
+    index: 0,
+  },
+}));
 const getConnectionByIndex = jest.fn(async () => ({
   connection: {
     endpoint: 'endpoint',
@@ -75,6 +83,7 @@ describe('getPortalSdk', () => {
       addShare,
       archiveDesignerProject,
       createDesignerProject,
+      getConnectionById,
       getConnectionByIndex,
       getDesignerProject,
       getDesignerProjects,
@@ -221,6 +230,12 @@ describe('getPortalSdk', () => {
       const sdk = getPortalSdk();
 
       (getCurrentConnectionInfo as jest.Mock).mockReturnValue(info);
+
+      expect(await sdk?.getConnectionById('id')).not.toBeNull();
+      expect(getConnectionById).toHaveBeenCalledWith({
+        id: 'id',
+        org_domain: info?.organizationDomain,
+      });
 
       expect(await sdk?.getConnectionByIndex(0)).not.toBeNull();
       expect(getConnectionByIndex).toHaveBeenCalledWith({

--- a/src/getPortalSdk.ts
+++ b/src/getPortalSdk.ts
@@ -59,6 +59,14 @@ export const getPortalSdk = () => {
       const result = await sdk.addShare({ input });
       return result.addShare || null;
     },
+    getConnectionById: async (id: string) => {
+      const urlInfo = getCurrentConnectionInfo(window);
+      const result = await sdk.getConnectionById({
+        id,
+        org_domain: urlInfo?.organizationDomain,
+      });
+      return result.connection || null;
+    },
     getConnectionByIndex: async (index: number) => {
       const urlInfo = getCurrentConnectionInfo(window);
       const result = await sdk.getConnectionByIndex({

--- a/src/sdk/documents/getConnectionByIdQuery.graphql
+++ b/src/sdk/documents/getConnectionByIdQuery.graphql
@@ -1,0 +1,11 @@
+query getConnectionById($id: String!, $org_domain: String) {
+  connection: getConnectionById(id: $id, org_domain: $org_domain) {
+    token
+    username
+    endpoint
+    dashboard
+    id
+    name
+    index
+  }
+}

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -1921,6 +1921,25 @@ export type CreateDesignerProjectMutation = {
   createDesignerProject: string;
 };
 
+export type GetConnectionByIdQueryVariables = Exact<{
+  id: Scalars['String'];
+  org_domain?: InputMaybe<Scalars['String']>;
+}>;
+
+export type GetConnectionByIdQuery = {
+  __typename?: 'Query';
+  connection?: {
+    __typename?: 'Connection';
+    token?: string | null;
+    username?: string | null;
+    endpoint: string;
+    dashboard?: string | null;
+    id: string;
+    name: string;
+    index: number;
+  } | null;
+};
+
 export type GetConnectionByIndexQueryVariables = Exact<{
   index: Scalars['Int'];
   org_domain?: InputMaybe<Scalars['String']>;
@@ -2180,6 +2199,19 @@ export const CreateDesignerProjectDocument = `
   )
 }
     `;
+export const GetConnectionByIdDocument = `
+    query getConnectionById($id: String!, $org_domain: String) {
+  connection: getConnectionById(id: $id, org_domain: $org_domain) {
+    token
+    username
+    endpoint
+    dashboard
+    id
+    name
+    index
+  }
+}
+    `;
 export const GetConnectionByIndexDocument = `
     query getConnectionByIndex($index: Int!, $org_domain: String) {
   connection: getConnectionByIndex(index: $index, org_domain: $org_domain) {
@@ -2430,6 +2462,21 @@ export function getSdk(
           ),
         'createDesignerProject',
         'mutation'
+      );
+    },
+    getConnectionById(
+      variables: GetConnectionByIdQueryVariables,
+      requestHeaders?: Dom.RequestInit['headers']
+    ): Promise<GetConnectionByIdQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<GetConnectionByIdQuery>(
+            GetConnectionByIdDocument,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders }
+          ),
+        'getConnectionById',
+        'query'
       );
     },
     getConnectionByIndex(


### PR DESCRIPTION
## Summary
- Adds `getConnectionById` to the portal-sdk public API, mirroring the existing `getConnectionByIndex` pattern
- The underlying GraphQL schema already supported `getConnectionById` but it wasn't wired up in the SDK or the `getPortalSdk()` wrapper
- Needed by [lassie#941](https://github.com/stardog-union/lassie/pull/941) to enable the share button with org connections

## Changes
- `src/sdk/index.ts` — Added `GetConnectionByIdQuery` types, GraphQL document, and SDK method
- `src/getPortalSdk.ts` — Added `getConnectionById(id)` wrapper that resolves org domain from the URL
- `src/__tests__/getPortalSdk.test.ts` — Added test coverage for the new method
- `src/__tests__/getCurrentConnectionFromPortal.test.ts` — Updated mock to include `getConnectionById`

## Test plan
- [x] All 35 existing + new tests pass
- [x] TypeScript compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)